### PR TITLE
共通ワークフローを定義、super-linterを導入

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,4 @@
+# VOICEVOX .github Workflow README
+
+`shared.yml`は全 VOICEVOX リポジトリで共通するワークフローをまとめたものです。
+`test.yml`をコピペして使うことを想定しています。

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,0 +1,19 @@
+name: VOICEVOX Shared Workflow
+
+on:
+  workflow_call:
+    inputs:
+      super_linter_env_vars:
+        type: string
+        description: "super linter用の環境変数定義。複数行のenv_name=env_value"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  super-linter:
+    name: Super Linter
+    uses: VOICEVOX/.github/.github/workflows/super-linter.yml@main
+    with:
+      env_vars: ${{ inputs.super_linter_env_vars }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,38 @@
+# https://github.com/super-linter/super-linter/blob/main/TEMPLATES/linter.yml
+---
+name: Super Linter
+
+on:
+  workflow_call:
+    inputs:
+      env_vars:
+        type: string
+        description: "env_name=env_value,..."
+
+jobs:
+  super-linter:
+    name: Super Linter
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 差分を取得するために必要
+
+      - name: Setup Environment Variables
+        if: ${{ inputs.env_vars }}
+        run: for line in "${{ inputs.env_vars }}"; do echo "$line" >> $GITHUB_ENV; done
+
+      - name: Lint Code Base
+        uses: super-linter/super-linter/slim@v5
+        env:
+          VALIDATE_ALL_CODEBASE: true # すべてのファイルを検証する。
+          VALIDATE_JSCPD: false # コピペ検出。厳しすぎるので無効化。
+          VALIDATE_NATURAL_LANGUAGE: false # 自然言語検出。英語のみなので無効化。
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test VOICEVOX Shared Workflow
+
+on:
+  push:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  voicevox-shared-workflow:
+    uses: VOICEVOX/.github/.github/workflows/shared.yml@main
+
+    # Super Linter に必要
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
+
+    # Pythonの検証を無効化する例
+    # with:
+    #   super_linter_env_vars: |
+    #     VALIDATE_PYTHON=false
+    #     VALIDATE_PYTHON_BLACK=false
+    #     VALIDATE_PYTHON_FLAKE8=false
+    #     VALIDATE_PYTHON_ISORT=false
+    #     VALIDATE_PYTHON_MYPY=false
+    #     VALIDATE_PYTHON_PYLINT=false


### PR DESCRIPTION
## 内容

全リポジトリで共通するgithubワークフロー処理がいくつかあります。markdownのリンターとか、誤字チェックとか。
そういった処理はそれぞれのリポジトリでそれぞれ管理されており、何か更新が必要なたびに全リポジトリにプルリクエストを送る必要があって大変です。

どうにかして共通するワークフローを定義したかったので、色々実験した末、今回のプルリクエストの提案に至りました。
まだかなり荒削りで、実験的な感じです。

* 流れの概要
	* `.github`リポジトリ（このリポジトリ）に共通処理ワークフローを一つ定義する
	* それぞれのリポジトリからgithub actionsのworkflow_callを使って共通ワークフローを実行する
	* 共通ワークフロー内から他のワークフローを実行する
* リポジトリに共通ワークフローを導入する流れ
	* このリポジトリの`test.yml`ワークフローをコピペすれば完了
* 現在の共通処理
	* とりあえずいろんなものをlintできる[super linter](https://github.com/super-linter/super-linter)を導入してみました
	* 主にmarkdownとbashファイルとgithub actionコードをlintするため
	* 将来は誤字脱字検出とかも導入したいかも

このリポジトリ自体も共通ワークフローを実行するようになっています。（1回マージしないと動かないかも）

## その他

super-linterは文字数制限の解除などいろんな設定が必要になってくると思います。
その時はこのリポジトリに設定ファイルを置けるようにしたいと思ってます。（git cloneにちょっとコツが必要ぽかったです）
